### PR TITLE
Replace npm with yarn in GitHub Action

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -29,7 +29,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker images
-        uses: iloveitaly/github-action-nixpacks@main
+        uses: iloveitaly/github-action-railpack@main
         with:
           platforms: "linux/amd64,linux/arm64"
           push: true


### PR DESCRIPTION
Switch from github-action-nixpacks to github-action-railpack for Docker image builds. Both are zero-config builders with the same API, but railpack uses Railway's buildpack system.